### PR TITLE
added sort case when numbers having digit at the end and rspecs

### DIFF
--- a/lib/naturally.rb
+++ b/lib/naturally.rb
@@ -34,6 +34,8 @@ module Naturally
         return @val.to_i <=> other.val.to_i
       elsif numbers_with_letters? || other.numbers_with_letters?
         return simple_normalize(@val) <=> simple_normalize(other.val)
+      elsif letters_with_numbers? || other.letters_with_numbers?
+        return reverse_simple_normalize(@val) <=> reverse_simple_normalize(other.val)
       else
         return @val <=> other.val
       end
@@ -46,6 +48,10 @@ module Naturally
     def numbers_with_letters?
       val =~ /^\d+[a-zA-Z]+$/
     end
+
+    def letters_with_numbers?
+      val =~ /^[a-zA-Z]+\d+$/
+    end
     
     def simple_normalize(n)
       if n =~ /^(\d+)([a-zA-Z]+)$/
@@ -53,7 +59,15 @@ module Naturally
       else 
         return [n.to_i]
       end
-    end    
+    end
+
+    def reverse_simple_normalize(_value)
+      if _value =~ /^([a-zA-Z]+)(\d+)$/
+        return [$1, $2.to_i]
+      else
+        return [_value.to_s]
+      end
+    end
   end
   
 end

--- a/spec/naturally_spec.rb
+++ b/spec/naturally_spec.rb
@@ -25,6 +25,12 @@ describe Naturally do
       b = %w[335 335.1 336 336a 337 337.1 337.2 337.15 337a]
       Naturally.sort(a).should == b
     end
+
+    it 'sorts when letters have numbers in them' do
+      a = %w[PC1, PC3, PC5, PC7, PC9, PC10, PC11, PC12, PC13, PC14, PROF2, PBLI, SBP1, SBP3]
+      b = %w[PBLI, PC1, PC3, PC5, PC7, PC9, PC10, PC11, PC12, PC13, PC14, PROF2, SBP1, SBP3]
+      Naturally.sort(a).should == b
+    end
     
     it 'sorts double digits with letters correctly' do
       a = %w[12a 12b 12c 13a 13b 2 3 4 5 10 11 12]


### PR DESCRIPTION
I have added a feature in which this gem will be able to sort the array of strings in way that if digits appear after alphabets in an element then the elements will be sorted numerically.

e.g. ["c1", "c10b", "c11a", "c2"]  #=> ["c1", "c2", "c11a", "c10b"]

Resolved issue #2 
