### PR TITLE
Added sort_by_block. Spec included.

### DIFF
--- a/lib/naturally.rb
+++ b/lib/naturally.rb
@@ -12,23 +12,17 @@ module Naturally
   end
 
   # Sort an array of objects "naturally" by a given attribute.
+  # If block is given, attribute is ignored and each object
+  # is yielded to the block to obtain the sort key.
   #
   # @param [Array<Object>] an_array the list of objects to sort.
   # @param [Symbol] an_attribute the attribute by which to sort.
-  # @return [Array<Object>] the objects in natural sort order.
-  def self.sort_by(an_array, an_attribute)
-    an_array.sort_by { |obj| normalize(obj.send(an_attribute)) }
-  end
-
-  # Sort an array of objects "naturally", yielding each object
-  # to the block to obtain the sort key.
-  #
-  # @param [Array<Object>] an_array the list of objects to sort.
   # @param [Block] &block a block that should evaluate to the
   #        sort key for the yielded object
   # @return [Array<Object>] the objects in natural sort order.
-  def self.sort_by_block(an_array, &block)
-    an_array.sort_by { |obj| normalize(yield(obj)) }
+  def self.sort_by(an_array, an_attribute=nil, &block)
+    return sort_by_block(an_array, &block) if block_given?
+    an_array.sort_by { |obj| normalize(obj.send(an_attribute)) }
   end
 
   # Convert the given number an array of {Segment}s.
@@ -45,5 +39,17 @@ module Naturally
   def self.normalize(complex_number)
     tokens = complex_number.to_s.scan(/\p{Word}+/)
     tokens.map { |t| Segment.new(t) }
+  end
+
+  private
+  # Sort an array of objects "naturally", yielding each object
+  # to the block to obtain the sort key.
+  #
+  # @param [Array<Object>] an_array the list of objects to sort.
+  # @param [Block] &block a block that should evaluate to the
+  #        sort key for the yielded object
+  # @return [Array<Object>] the objects in natural sort order.
+  def self.sort_by_block(an_array, &block)
+    an_array.sort_by { |obj| normalize(yield(obj)) }
   end
 end

--- a/lib/naturally.rb
+++ b/lib/naturally.rb
@@ -20,6 +20,17 @@ module Naturally
     an_array.sort_by { |obj| normalize(obj.send(an_attribute)) }
   end
 
+  # Sort an array of objects "naturally", yielding each object
+  # to the block to obtain the sort key.
+  #
+  # @param [Array<Object>] an_array the list of objects to sort.
+  # @param [Block] &block a block that should evaluate to the
+  #        sort key for the yielded object
+  # @return [Array<Object>] the objects in natural sort order.
+  def self.sort_by_block(an_array, &block)
+    an_array.sort_by { |obj| normalize(yield(obj)) }
+  end
+
   # Convert the given number an array of {Segment}s.
   # This enables it to be sorted against other arrays
   # by the standard #sort method.

--- a/spec/naturally_spec.rb
+++ b/spec/naturally_spec.rb
@@ -120,7 +120,7 @@ describe Naturally do
         {:name => 'Quantal Quetzal',  :version => '12.10'},
         {:name => 'Lucid Lynx',       :version => '10.04.4'}
       ]
-      actual = Naturally.sort_by_block(releases){|r| r[:version]}
+      actual = Naturally.sort_by(releases){|r| r[:version]}
       expect(actual.map{|r| r[:name]}).to eq [
         'Lucid Lynx',
         'Maverick Meerkat',

--- a/spec/naturally_spec.rb
+++ b/spec/naturally_spec.rb
@@ -109,4 +109,26 @@ describe Naturally do
       )
     end
   end
+
+  describe '#sort_naturally_by_block' do
+    it 'sorts using a block' do
+      releases = [
+        {:name => 'Saucy Salamander', :version => '13.10'},
+        {:name => 'Raring Ringtail',  :version => '13.04'},
+        {:name => 'Precise Pangolin', :version => '12.04.4'},
+        {:name => 'Maverick Meerkat', :version => '10.10'},
+        {:name => 'Quantal Quetzal',  :version => '12.10'},
+        {:name => 'Lucid Lynx',       :version => '10.04.4'}
+      ]
+      actual = Naturally.sort_by_block(releases){|r| r[:version]}
+      expect(actual.map{|r| r[:name]}).to eq [
+        'Lucid Lynx',
+        'Maverick Meerkat',
+        'Precise Pangolin',
+        'Quantal Quetzal',
+        'Raring Ringtail',
+        'Saucy Salamander'
+      ]
+    end
+  end
 end


### PR DESCRIPTION
This could be trivially reimplemented as an addition directly to `#sort` by using `Kernel#block_given?`. Since I didn't know whether that would be desirable, I implemented it as a completely separate method. Spec contains example use.