### PR TITLE
Lower minimum Ruby version to 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
 rvm:
+  - 2.0
   - 2.1
   - 2.2

--- a/naturally.gemspec
+++ b/naturally.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |gem|
   gem.summary       = %q{Sorts numbers according to the way people are used to seeing them.}
   gem.description   = %q{Natural Sorting with support for legal numbering, course numbers, and other number/letter mixes.}
   gem.homepage      = "http://github.com/dogweather/naturally"
-  gem.required_ruby_version = '>= 2.1'
+  gem.required_ruby_version = '>= 2.0'
 
   gem.files         = `git ls-files`.split($/)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }

--- a/spec/naturally_spec.rb
+++ b/spec/naturally_spec.rb
@@ -1,7 +1,10 @@
+# coding: utf-8
 require 'naturally'
 
 describe Naturally do
-  def it_sorts(this:, to_this:)
+  def it_sorts(opts = {})
+    this = opts[:this]
+    to_this = opts[:to_this]
     actual = Naturally.sort(this)
     expect(actual).to eq(to_this)
   end


### PR DESCRIPTION
Hey there. It looks to me like there are no real dependencies on Ruby 2.1, except for one use of keyword args in the specs. After changing that one instance, all specs pass using Ruby 2.0. I know it's old, but if it works fine and isn't hindering development in any real way, I think it's a good change.

At the very least this lets us use the version of Ruby shipped with CentOS/Redhat 7.

Thoughts?